### PR TITLE
Avoid double slashes in URL

### DIFF
--- a/Pod/Classes/ABTracker.m
+++ b/Pod/Classes/ABTracker.m
@@ -57,7 +57,7 @@
     NSDictionary *events = [[NSDictionary alloc] initWithObjectsAndKeys:event, @"data", nil];
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:events options:kNilOptions error:nil];
     
-    NSString *urlString = [kBaseUrl stringByAppendingString:@"/api/events"];
+    NSString *urlString = [kBaseUrl stringByAppendingPathComponent:@"/api/events"];
     
     NSURL* url = [NSURL URLWithString:urlString];
     NSMutableURLRequest *configRequest = [NSMutableURLRequest requestWithURL:url


### PR DESCRIPTION
The generated URL was `https://abtracker.herokuapp.com//api/events`/ 
To avoid this, `stringByAppendingPathComponent` can be used
